### PR TITLE
unlock for Contao 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     },
     "require":{
       "php":">=5.3",
-      "contao/core":">=3.0.6,<4",
-      "contao-community-alliance/composer-installer":"*"
+      "contao/core-bundle":"^3.0.6|^4.0",
+      "contao-community-alliance/composer-plugin":"^2.4|^3.0"
     },
     "replace":{
       "contao-legacy/mae_event_categories":"self.version"


### PR DESCRIPTION
Extension seems to work without problems in Contao 4, so it should be unlocked.